### PR TITLE
Fix issue with building cryptography package

### DIFF
--- a/src/fumblechain/requirements.txt
+++ b/src/fumblechain/requirements.txt
@@ -4,5 +4,5 @@ twisted; python_version >= '3.0'
 flask; python_version >= '3.0'
 APScheduler
 requests
-cryptography
+cryptography==3.3.2
 peewee


### PR DESCRIPTION
Due to the cryptography-package recently introducing rust (and cargo) as build dependencies in cryptography versions > 3.3.2 (see https://github.com/pyca/cryptography/issues/5771), the init_ctf.sh script fails to build the docker containers:

```
  error: can't find Rust compiler
  
  If you are using an outdated pip version, it is possible a prebuilt wheel is available for this package but pip is not able to install from it. Installing from the wheel would avoid the need for a Rust compiler.
  
  To update pip, run:
  
      pip install --upgrade pip
  
  and then retry package installation.
  
  If you did intend to build this package from source, try installing a Rust compiler from your system package manager and ensure it is on the PATH during installation. Alternatively, rustup (available at https://rustup.rs) is the recommended way to download and update the Rust compiler toolchain.
  
  This package requires Rust >=1.41.0.
  ----------------------------------------
  ERROR: Failed building wheel for cryptography
```

Installing rust and cargo in each container makes the compilation of cryptography take forever, and since this is purposely vulnerable software, pinning the package to 3.3.2 in requirements.txt should be fine.
